### PR TITLE
Refactor code and fix byte order during parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.30)
 project(ParseIdentify VERSION 1.0)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # CPACK WIX properties
@@ -26,6 +26,7 @@ include(CPack)
 add_executable(ParseIdentify 
     main.cpp
     src/parser.cpp
+    src/pprinter.cpp
 )
 
 install(TARGETS ParseIdentify DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ include(CPack)
 add_executable(ParseIdentify 
     main.cpp
     src/parser.cpp
-    src/pprinter.cpp
 )
 
 install(TARGETS ParseIdentify DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ set(CPACK_SOURCE_GENERATOR "WIX")
 
 include(CPack)
 
-add_executable(ParseIdentify main.cpp)
+add_executable(ParseIdentify 
+    main.cpp
+    src/parser.cpp
+)
 
 install(TARGETS ParseIdentify DESTINATION bin)

--- a/main.cpp
+++ b/main.cpp
@@ -5,22 +5,32 @@
 
 #define SMART_SELF_TEST_SUPPORTED 2 // Bitflag for SMART self-test support, bit 1 of word 87.
 
+const int ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
+
 int main(int argc, char *argv[])
 {
-	// TODO: add --help
-
-	if (argc < 2)
+	// Check if the user provided an argument.
+	if ( argc != 2 || std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")
 	{
-		std::cerr << "Usage: " << argv[0] << " <input_file>" << std::endl;
+		const std::string error_log = "Usage: " + std::string(argv[0]) + " file_path\n";
+		std::cerr << error_log;
 		return 1;
 	}
 
-	// TODO: file type checks (.bin)
-	std::string filename = argv[1];
+	std::string file_path = argv[1];
 
-	std::cout << "Opening file: " << filename << std::endl;
+	// Check if the file extension is .bin. Return error if not.
+	std::string file_ext = file_path.substr(file_path.find_last_of("."));
+	if (file_ext != ".bin")
+	{
+		const std::string error_log = "Error: expected a binary file (.bin), but got (" + file_ext + ") instead.\n";
+		std::cerr << error_log;
+		return 1;
+	}
+	
+	std::cout << "Opening file: " << file_path << std::endl;
 
-	const int ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
+	// TODO: move these constants to the parser header file.
 	const int word_size_bytes = 2;								// 2 bytes per word
 	const int model_number_start_bytes = 27 * word_size_bytes;	// 27th word
 	const int model_number_size_bytes = 20 * word_size_bytes;	// 20 words
@@ -29,16 +39,16 @@ int main(int argc, char *argv[])
 	const int smart_start_bytes = (87 * word_size_bytes) + 1; // 87th word, bits 0-7
 	const int smart_size_bytes = 1;							  // LSB of 87th word
 
-	std::ifstream file(filename, std::ios::binary | std::ios::ate); // ios::ate so pointer starts at end of file to get its size
+	std::ifstream file(file_path, std::ios::binary | std::ios::ate); // ios::ate so pointer starts at end of file to get its size
 
 	if (file.is_open())
 	{
 		// process file
 		// TODO: raise error if binary file is not 512 bytes
-		int size_bytes = static_cast<int>(file.tellg());
-		std::cout << "File size: " << size_bytes << " bytes" << std::endl;
+		const int SIZE_BYTES = static_cast<int>(file.tellg());
+		std::cout << "File size: " << SIZE_BYTES << " bytes" << std::endl;
 
-		// char buffer[size_bytes];
+		// char buffer[SIZE_BYTES];
 		std::array<char, ATA_IDENTIFY_SIZE> buffer;
 		file.seekg(0, std::ios::beg);
 		file.read(buffer.data(), buffer.size());
@@ -97,7 +107,7 @@ int main(int argc, char *argv[])
 	}
 	else
 	{
-		std::cerr << "Unable to open file: " << filename << std::endl;
+		std::cerr << "Unable to open file: " << file_path << std::endl;
 		return 1;
 	}
 	return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -64,9 +64,12 @@ int main(int argc, char *argv[])
 	file.read(buffer.data(), buffer.size());
 	file.close();
 
+	// DO NOT modify buffer after this point — use const_buffer only
+	const std::array<char, ATA_IDENTIFY_SIZE>& const_buffer = buffer;
+
 	// Model number - words 27-46 (little-endian)
 	char model_number_buffer[model_number_size_bytes];
-	std::memcpy(model_number_buffer, buffer.data() + model_number_start_bytes, model_number_size_bytes);
+	std::memcpy(model_number_buffer, const_buffer.data() + model_number_start_bytes, model_number_size_bytes);
 	std::string model_number;
 
 	for (int i = 0; i < model_number_size_bytes; i += word_size_bytes)
@@ -84,7 +87,7 @@ int main(int argc, char *argv[])
 
 	// Supported Ultra DMA modes, bits 0-7, MSB first
 	char supported_dma_buffer[supported_dma_size_bytes];
-	std::memcpy(supported_dma_buffer, buffer.data() + supported_dma_start_bytes, supported_dma_size_bytes);
+	std::memcpy(supported_dma_buffer, const_buffer.data() + supported_dma_start_bytes, supported_dma_size_bytes);
 
 	// IntegerLogObvious: https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
 	unsigned int v = static_cast<unsigned int>(supported_dma_buffer[1]); // LSB contains the supported dma modes
@@ -109,7 +112,7 @@ int main(int argc, char *argv[])
 	// SMART self-test support is in LSB of word 87, bit 1.
 	// TODO: check if the buffer is assigned the correct byte. Use bitset to double-check.
 	unsigned char smart_buffer[1];
-	std::memcpy(smart_buffer, buffer.data() + smart_start_bytes, smart_size_bytes);
+	std::memcpy(smart_buffer, const_buffer.data() + smart_start_bytes, smart_size_bytes);
 	if ((smart_buffer[0] & SMART_SELF_TEST_SUPPORTED) == SMART_SELF_TEST_SUPPORTED)
 		std::cout << "SMART self-test supported." << std::endl;
 	else

--- a/main.cpp
+++ b/main.cpp
@@ -1,119 +1,43 @@
 #include <iostream>
-#include <fstream>
 #include <string>
 #include <array>
 
-#define SMART_SELF_TEST_SUPPORTED 2 // Bitflag for SMART self-test support, bit 1 of word 87.
+#include "src/parser.h"
 
-const int ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
 
 int main(int argc, char *argv[])
 {
 	// Check if the user provided an argument.
 	if (argc != 2 || std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")
 	{
-		const std::string error_log = "Usage: " + std::string(argv[0]) + " file_path\n";
-		std::cerr << error_log;
+		const std::string error_message = "Usage: " + std::string(argv[0]) + " file_path\n";
+		std::cerr << error_message;
 		return 1;
 	}
 
 	std::string file_path = argv[1];
 
-	// Check if the file extension is .bin. Return error if not.
-	std::string file_ext = file_path.substr(file_path.find_last_of("."));
-	if (file_ext != ".bin")
-	{
-		const std::string error_log = "Error: expected a binary file (.bin), but got (" + file_ext + ") instead.\n";
-		std::cerr << error_log;
-		return 1;
-	}
-
 	std::cout << "Opening file: " << file_path << std::endl;
 
-	// TODO: move these constants to the parser header file.
-	const int word_size_bytes = 2;								// 2 bytes per word
-	const int model_number_start_bytes = 27 * word_size_bytes;	// 27th word
-	const int model_number_size_bytes = 20 * word_size_bytes;	// 20 words
-	const int supported_dma_start_bytes = 88 * word_size_bytes; // 88th word
-	const int supported_dma_size_bytes = 1 * word_size_bytes;
-	const int smart_start_bytes = (87 * word_size_bytes) + 1; // 87th word, bits 0-7
-	const int smart_size_bytes = 1;							  // LSB of 87th word
+	std::array<char, ATA_IDENTIFY_SIZE> file_buffer = read_file_to_buffer(file_path);
 
-	std::ifstream file(file_path, std::ios::binary | std::ios::ate); // ios::ate so pointer starts at end of file to get its size
+	std::cout << "File successfully opened.\n";
 
-	// Raise error if unable to open file
-	if (!file.is_open())
-	{
-		std::cerr << "Error: unable to open file. Does it exist and have correct access permissions?\n";
-		return 1;
-	}
-
-	std::array<char, ATA_IDENTIFY_SIZE> buffer; // Buffer for all the 512 bytes of data
-	const int SIZE_BYTES = static_cast<int>(file.tellg());
-
-	// Raise error if the file is not 512 bytes
-	if (SIZE_BYTES != 512)
-	{
-		const std::string error_log = "Error: expected 512 bytes when reading the file, but got " + std::to_string(SIZE_BYTES) + " bytes instead.\n";
-		std::cerr << error_log;
-		return 1;
-	}
-
-	// Load file contents into the buffer
-	file.seekg(0, std::ios::beg);
-	file.read(buffer.data(), buffer.size());
-	file.close();
-
-	// DO NOT modify buffer after this point — use const_buffer only
-	const std::array<char, ATA_IDENTIFY_SIZE>& const_buffer = buffer;
-
-	// Model number - words 27-46 (little-endian)
-	char model_number_buffer[model_number_size_bytes];
-	std::memcpy(model_number_buffer, const_buffer.data() + model_number_start_bytes, model_number_size_bytes);
-	std::string model_number;
-
-	for (int i = 0; i < model_number_size_bytes; i += word_size_bytes)
-	{
-		model_number += model_number_buffer[i + 1];
-		model_number += model_number_buffer[i];
-	}
-	// Model number has trailing white space from leftover bytes. Remove them.
-	model_number.erase(model_number.find_last_not_of(' ') + 1);
+	// Parse the file buffer
+	std::string model_number = extract_model_number(file_buffer);
+	unsigned int highest_dma_mode = extract_dma_mode(file_buffer);
+	bool smart_support = extract_smart_support(file_buffer);
 
 	std::cout << std::endl
 			  << "--- ATA IDENTIFY ---" << std::endl;
 
 	std::cout << "Model Number: " << model_number << std::endl;
-
-	// Supported Ultra DMA modes, bits 0-7, MSB first
-	char supported_dma_buffer[supported_dma_size_bytes];
-	std::memcpy(supported_dma_buffer, const_buffer.data() + supported_dma_start_bytes, supported_dma_size_bytes);
-
-	// IntegerLogObvious: https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
-	unsigned int v = static_cast<unsigned int>(supported_dma_buffer[1]); // LSB contains the supported dma modes
-	unsigned r = 0;														 // Counter for bit shifts, also lg(v).
-
-	while (v)
-	{
-		v >>= 1;
-		r++;
-	}
-	// r-1 is the highest supported mode
-	// TODO: figure out a cleaner way to pretty print.
-	if (r == 0)
-		std::cout << "No Ultra DMA modes supported." << std::endl;
-	else if (r == 1)
-		std::cout << "Ultra DMA mode " << r - 1 << " is supported." << std::endl;
-	else if (r > 7)
-		std::cerr << "Error: r > 7 despite bit 7 being reserved. This should not happen." << std::endl;
+	if (highest_dma_mode == 0)
+		std::cout << "Ultra DMA mode " << highest_dma_mode << " is supported." << std::endl;
 	else
-		std::cout << "Ultra DMA modes " << r - 1 << " and below are supported." << std::endl;
+		std::cout << "Ultra DMA modes " << highest_dma_mode << " and below are supported." << std::endl;
 
-	// SMART self-test support is in LSB of word 87, bit 1.
-	// TODO: check if the buffer is assigned the correct byte. Use bitset to double-check.
-	unsigned char smart_buffer[1];
-	std::memcpy(smart_buffer, const_buffer.data() + smart_start_bytes, smart_size_bytes);
-	if ((smart_buffer[0] & SMART_SELF_TEST_SUPPORTED) == SMART_SELF_TEST_SUPPORTED)
+	if (smart_support)
 		std::cout << "SMART self-test supported." << std::endl;
 	else
 		std::cout << "SMART self-test not supported." << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <fstream>
-#include <cstring>
+#include <string>
 #include <array>
 
 #define SMART_SELF_TEST_SUPPORTED 2 // Bitflag for SMART self-test support, bit 1 of word 87.
@@ -10,7 +10,7 @@ const int ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
 int main(int argc, char *argv[])
 {
 	// Check if the user provided an argument.
-	if ( argc != 2 || std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")
+	if (argc != 2 || std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")
 	{
 		const std::string error_log = "Usage: " + std::string(argv[0]) + " file_path\n";
 		std::cerr << error_log;
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
 		std::cerr << error_log;
 		return 1;
 	}
-	
+
 	std::cout << "Opening file: " << file_path << std::endl;
 
 	// TODO: move these constants to the parser header file.
@@ -41,74 +41,79 @@ int main(int argc, char *argv[])
 
 	std::ifstream file(file_path, std::ios::binary | std::ios::ate); // ios::ate so pointer starts at end of file to get its size
 
-	if (file.is_open())
+	// Raise error if unable to open file
+	if (!file.is_open())
 	{
-		// process file
-		// TODO: raise error if binary file is not 512 bytes
-		const int SIZE_BYTES = static_cast<int>(file.tellg());
-		std::cout << "File size: " << SIZE_BYTES << " bytes" << std::endl;
-
-		// char buffer[SIZE_BYTES];
-		std::array<char, ATA_IDENTIFY_SIZE> buffer;
-		file.seekg(0, std::ios::beg);
-		file.read(buffer.data(), buffer.size());
-		file.close();
-
-		// Model number - words 27-46 (little-endian)
-		char model_number_buffer[model_number_size_bytes];
-		std::memcpy(model_number_buffer, buffer.data() + model_number_start_bytes, model_number_size_bytes);
-		std::string model_number;
-
-		for (int i = 0; i < model_number_size_bytes; i += word_size_bytes)
-		{
-			model_number += model_number_buffer[i + 1];
-			model_number += model_number_buffer[i];
-		}
-		// Model number has trailing white space from leftover bytes. Remove them.
-		model_number.erase(model_number.find_last_not_of(' ') + 1);
-
-		std::cout << std::endl
-				  << "--- ATA IDENTIFY ---" << std::endl;
-
-		std::cout << "Model Number: " << model_number << std::endl;
-
-		// Supported Ultra DMA modes, bits 0-7, MSB first
-		char supported_dma_buffer[supported_dma_size_bytes];
-		std::memcpy(supported_dma_buffer, buffer.data() + supported_dma_start_bytes, supported_dma_size_bytes);
-
-		// IntegerLogObvious: https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
-		unsigned int v = static_cast<unsigned int>(supported_dma_buffer[1]); // LSB contains the supported dma modes
-		unsigned r = 0;														 // Counter for bit shifts, also lg(v).
-
-		while (v)
-		{
-			v >>= 1;
-			r++;
-		}
-		// r-1 is the highest supported mode
-		// TODO: figure out a cleaner way to pretty print.
-		if (r == 0)
-			std::cout << "No Ultra DMA modes supported." << std::endl;
-		else if (r == 1)
-			std::cout << "Ultra DMA mode " << r - 1 << " is supported." << std::endl;
-		else if (r > 7)
-			std::cerr << "Error: r > 7 despite bit 7 being reserved. This should not happen." << std::endl;
-		else
-			std::cout << "Ultra DMA modes " << r - 1 << " and below are supported." << std::endl;
-
-		// SMART self-test support is in LSB of word 87, bit 1.
-		// TODO: check if the buffer is assigned the correct byte. Use bitset to double-check.
-		unsigned char smart_buffer[1];
-		std::memcpy(smart_buffer, buffer.data() + smart_start_bytes, smart_size_bytes);
-		if ((smart_buffer[0] & SMART_SELF_TEST_SUPPORTED) == SMART_SELF_TEST_SUPPORTED)
-			std::cout << "SMART self-test supported." << std::endl;
-		else
-			std::cout << "SMART self-test not supported." << std::endl;
-	}
-	else
-	{
-		std::cerr << "Unable to open file: " << file_path << std::endl;
+		std::cerr << "Error: unable to open file. Does it exist and have correct access permissions?\n";
 		return 1;
 	}
+
+	std::array<char, ATA_IDENTIFY_SIZE> buffer; // Buffer for all the 512 bytes of data
+	const int SIZE_BYTES = static_cast<int>(file.tellg());
+
+	// Raise error if the file is not 512 bytes
+	if (SIZE_BYTES != 512)
+	{
+		const std::string error_log = "Error: expected 512 bytes when reading the file, but got " + std::to_string(SIZE_BYTES) + " bytes instead.\n";
+		std::cerr << error_log;
+		return 1;
+	}
+
+	// Load file contents into the buffer
+	file.seekg(0, std::ios::beg);
+	file.read(buffer.data(), buffer.size());
+	file.close();
+
+	// Model number - words 27-46 (little-endian)
+	char model_number_buffer[model_number_size_bytes];
+	std::memcpy(model_number_buffer, buffer.data() + model_number_start_bytes, model_number_size_bytes);
+	std::string model_number;
+
+	for (int i = 0; i < model_number_size_bytes; i += word_size_bytes)
+	{
+		model_number += model_number_buffer[i + 1];
+		model_number += model_number_buffer[i];
+	}
+	// Model number has trailing white space from leftover bytes. Remove them.
+	model_number.erase(model_number.find_last_not_of(' ') + 1);
+
+	std::cout << std::endl
+			  << "--- ATA IDENTIFY ---" << std::endl;
+
+	std::cout << "Model Number: " << model_number << std::endl;
+
+	// Supported Ultra DMA modes, bits 0-7, MSB first
+	char supported_dma_buffer[supported_dma_size_bytes];
+	std::memcpy(supported_dma_buffer, buffer.data() + supported_dma_start_bytes, supported_dma_size_bytes);
+
+	// IntegerLogObvious: https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
+	unsigned int v = static_cast<unsigned int>(supported_dma_buffer[1]); // LSB contains the supported dma modes
+	unsigned r = 0;														 // Counter for bit shifts, also lg(v).
+
+	while (v)
+	{
+		v >>= 1;
+		r++;
+	}
+	// r-1 is the highest supported mode
+	// TODO: figure out a cleaner way to pretty print.
+	if (r == 0)
+		std::cout << "No Ultra DMA modes supported." << std::endl;
+	else if (r == 1)
+		std::cout << "Ultra DMA mode " << r - 1 << " is supported." << std::endl;
+	else if (r > 7)
+		std::cerr << "Error: r > 7 despite bit 7 being reserved. This should not happen." << std::endl;
+	else
+		std::cout << "Ultra DMA modes " << r - 1 << " and below are supported." << std::endl;
+
+	// SMART self-test support is in LSB of word 87, bit 1.
+	// TODO: check if the buffer is assigned the correct byte. Use bitset to double-check.
+	unsigned char smart_buffer[1];
+	std::memcpy(smart_buffer, buffer.data() + smart_start_bytes, smart_size_bytes);
+	if ((smart_buffer[0] & SMART_SELF_TEST_SUPPORTED) == SMART_SELF_TEST_SUPPORTED)
+		std::cout << "SMART self-test supported." << std::endl;
+	else
+		std::cout << "SMART self-test not supported." << std::endl;
+
 	return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 	// Parse the file buffer
 	std::string model_number = extract_model_number(file_buffer);
 	unsigned int highest_dma_mode = extract_dma_mode(file_buffer);
-	bool smart_support = extract_smart_support(file_buffer);
+	bool smart_supported = extract_smart_support(file_buffer);
 
 	std::cout << std::endl
 			  << "--- ATA IDENTIFY ---" << std::endl;
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 	else
 		std::cout << "Ultra DMA modes " << highest_dma_mode << " and below are supported." << std::endl;
 
-	if (smart_support)
+	if (smart_supported)
 		std::cout << "SMART self-test supported." << std::endl;
 	else
 		std::cout << "SMART self-test not supported." << std::endl;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,0 +1,109 @@
+#include "parser.h"
+
+#include <fstream>
+
+
+// TODO: it'd be better to define parser as a class and store the file buffer as read-only.
+
+std::array<char, ATA_IDENTIFY_SIZE> read_file_to_buffer(const std::string &file_path)
+{
+    // Throw error if the file extension is not .bin
+	std::string file_ext = file_path.substr(file_path.find_last_of("."));
+	if (file_ext != ".bin")
+	{
+        throw std::runtime_error("Error: expected a binary file (.bin), but got (" + file_ext + ") instead.");
+	}
+
+    std::ifstream file(file_path, std::ios::binary | std::ios::ate); // ios::ate so pointer starts at end of file to get its size
+
+	// Throw error if unable to open file
+	if (!file.is_open())
+	{
+        throw std::runtime_error("Error: unable to open file. Does it exist and have correct access permissions?");
+	}
+
+    std::array<char, ATA_IDENTIFY_SIZE> file_buffer;
+	const std::size_t FILE_SIZE = static_cast<int>(file.tellg());
+
+	// Throw error if the file is not 512 bytes
+	if (FILE_SIZE != 512)
+	{
+        throw std::runtime_error("Error: expected 512 bytes when reading the file, but got " + std::to_string(FILE_SIZE) + " bytes instead.");
+	}
+
+	file.seekg(0, std::ios::beg);
+	file.read(file_buffer.data(), file_buffer.size());
+	file.close();
+    return file_buffer;
+}
+
+
+
+
+std::string extract_model_number(std::array<char, ATA_IDENTIFY_SIZE> &file_buffer)
+{
+    // Model number is in words 27-46. Note: the word pairs are little-endian.
+    constexpr std::size_t START_BYTES = 27 * ATA_WORD_SIZE_BYTES; // 27th word
+    constexpr std::size_t SIZE_BYTES = 20 * ATA_WORD_SIZE_BYTES;  // 20 words long
+
+    char buffer[SIZE_BYTES];
+    std::memcpy(buffer, file_buffer.data() + START_BYTES, SIZE_BYTES);
+    std::string model_number;
+
+    // 2-word pairs are little endian, so we must flip them
+    for (int i = 0; i < SIZE_BYTES; i += ATA_WORD_SIZE_BYTES)
+    {
+        model_number += buffer[i + 1];
+        model_number += buffer[i];
+    }
+    // Model number has trailing white space from leftover bytes. Remove them.
+    model_number.erase(model_number.find_last_not_of(' ') + 1);
+    return model_number;
+}
+
+unsigned int extract_dma_mode(std::array<char, ATA_IDENTIFY_SIZE> &file_buffer)
+{
+    // Supported Ultra DMA modes are in the 88th word, bits 0-7. Note: MSB first.
+    constexpr std::size_t START_BYTES = 88 * ATA_WORD_SIZE_BYTES; // 88th word
+    constexpr std::size_t SIZE_BYTES = 1 * ATA_WORD_SIZE_BYTES;   // 1 word only
+
+    char buffer[SIZE_BYTES];
+    std::memcpy(buffer, file_buffer.data() + START_BYTES, SIZE_BYTES);
+
+    // IntegerLogObvious: https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
+    unsigned int lsb = static_cast<unsigned int>(buffer[1]); // LSB contains the supported dma modes
+    unsigned int bit_shifts = 0;                             // Also lg(lsb).
+
+    while (lsb)
+    {
+        lsb >>= 1;
+        bit_shifts++;
+
+        // Bit 7 is reserved, so we stop here.
+        if (bit_shifts == 7)
+        {
+            break;
+        }
+    }
+
+    unsigned int highest_supported_mode = bit_shifts - 1;
+    return highest_supported_mode;
+}
+
+bool extract_smart_support(std::array<char, ATA_IDENTIFY_SIZE> &file_buffer)
+{
+    // SMART self-test support (from 'Command set/feature enabled/supported') is in word 87, bit 1.
+    constexpr std::size_t START_BYTES = 87 * ATA_WORD_SIZE_BYTES; // 87th word
+    constexpr std::size_t SIZE_BYTES = 1 * ATA_WORD_SIZE_BYTES;                           // 1 word only
+
+    // Bitflag for bit 1 (LSB)
+    constexpr uint16_t SMART_SELF_TEST_SUPPORTED_BITMASK = 0b0000000000000010;
+
+    unsigned char smart_buffer[SIZE_BYTES];
+    std::memcpy(smart_buffer, file_buffer.data() + START_BYTES, SIZE_BYTES);
+    
+
+    //TODO: investigate access of smart_buffer[0]. Shouldn't it be 1 instead, since we're lookign at bit 1, which is in the LSB (second byte of the word)? Is there a better way of checking this?
+    bool smart_support = (smart_buffer[0] & SMART_SELF_TEST_SUPPORTED_BITMASK) != 0;
+    return smart_support;
+}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2,56 +2,53 @@
 
 #include <fstream>
 
-
 // TODO: it'd be better to define parser as a class and store the file buffer as read-only.
+// TODO: good idea to put `read_file_to_buffer` in the constructor so it throws immediatelly if the file is not valid.
 
 std::array<char, ATA_IDENTIFY_SIZE> read_file_to_buffer(const std::string &file_path)
 {
     // Throw error if the file extension is not .bin
-	std::string file_ext = file_path.substr(file_path.find_last_of("."));
-	if (file_ext != ".bin")
-	{
+    std::string file_ext = file_path.substr(file_path.find_last_of("."));
+    if (file_ext != ".bin")
+    {
         throw std::runtime_error("Error: expected a binary file (.bin), but got (" + file_ext + ") instead.");
-	}
+    }
 
     std::ifstream file(file_path, std::ios::binary | std::ios::ate); // ios::ate so pointer starts at end of file to get its size
 
-	// Throw error if unable to open file
-	if (!file.is_open())
-	{
+    // Throw error if unable to open file
+    if (!file.is_open())
+    {
         throw std::runtime_error("Error: unable to open file. Does it exist and have correct access permissions?");
-	}
+    }
 
     std::array<char, ATA_IDENTIFY_SIZE> file_buffer;
-	const std::size_t FILE_SIZE = static_cast<int>(file.tellg());
+    const std::size_t FILE_SIZE = static_cast<int>(file.tellg());
 
-	// Throw error if the file is not 512 bytes
-	if (FILE_SIZE != 512)
-	{
+    // Throw error if the file is not 512 bytes
+    if (FILE_SIZE != 512)
+    {
         throw std::runtime_error("Error: expected 512 bytes when reading the file, but got " + std::to_string(FILE_SIZE) + " bytes instead.");
-	}
+    }
 
-	file.seekg(0, std::ios::beg);
-	file.read(file_buffer.data(), file_buffer.size());
-	file.close();
+    file.seekg(0, std::ios::beg);
+    file.read(file_buffer.data(), file_buffer.size());
+    file.close();
     return file_buffer;
 }
-
-
-
 
 std::string extract_model_number(std::array<char, ATA_IDENTIFY_SIZE> &file_buffer)
 {
     // Model number is in words 27-46. Note: the word pairs are little-endian.
-    constexpr std::size_t START_BYTES = 27 * ATA_WORD_SIZE_BYTES; // 27th word
-    constexpr std::size_t SIZE_BYTES = 20 * ATA_WORD_SIZE_BYTES;  // 20 words long
+    constexpr std::size_t START_BYTES = 54; // 27th word
+    constexpr std::size_t SIZE_BYTES = 40;  // 20 words long
 
     char buffer[SIZE_BYTES];
     std::memcpy(buffer, file_buffer.data() + START_BYTES, SIZE_BYTES);
     std::string model_number;
 
     // 2-word pairs are little endian, so we must flip them
-    for (int i = 0; i < SIZE_BYTES; i += ATA_WORD_SIZE_BYTES)
+    for (int i = 0; i < SIZE_BYTES; i += 2)
     {
         model_number += buffer[i + 1];
         model_number += buffer[i];
@@ -63,16 +60,12 @@ std::string extract_model_number(std::array<char, ATA_IDENTIFY_SIZE> &file_buffe
 
 unsigned int extract_dma_mode(std::array<char, ATA_IDENTIFY_SIZE> &file_buffer)
 {
-    // Supported Ultra DMA modes are in the 88th word, bits 0-7. Note: MSB first.
-    constexpr std::size_t START_BYTES = 88 * ATA_WORD_SIZE_BYTES; // 88th word
-    constexpr std::size_t SIZE_BYTES = 1 * ATA_WORD_SIZE_BYTES;   // 1 word only
-
-    char buffer[SIZE_BYTES];
-    std::memcpy(buffer, file_buffer.data() + START_BYTES, SIZE_BYTES);
+    // Supported Ultra DMA modes are in the 88th word, bits 0-7.
+    constexpr std::size_t START_BYTES = 176; // 88th word
 
     // IntegerLogObvious: https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
-    unsigned int lsb = static_cast<unsigned int>(buffer[1]); // LSB contains the supported dma modes
-    unsigned int bit_shifts = 0;                             // Also lg(lsb).
+    unsigned int lsb = static_cast<unsigned int>(file_buffer[START_BYTES]); // LSB contains the supported dma modes
+    unsigned int bit_shifts = 0;                                            // Also lg(lsb).
 
     while (lsb)
     {
@@ -93,17 +86,11 @@ unsigned int extract_dma_mode(std::array<char, ATA_IDENTIFY_SIZE> &file_buffer)
 bool extract_smart_support(std::array<char, ATA_IDENTIFY_SIZE> &file_buffer)
 {
     // SMART self-test support (from 'Command set/feature enabled/supported') is in word 87, bit 1.
-    constexpr std::size_t START_BYTES = 87 * ATA_WORD_SIZE_BYTES; // 87th word
-    constexpr std::size_t SIZE_BYTES = 1 * ATA_WORD_SIZE_BYTES;                           // 1 word only
+    constexpr std::size_t START_BYTES = 174; // 87th word
 
     // Bitflag for bit 1 (LSB)
-    constexpr uint16_t SMART_SELF_TEST_SUPPORTED_BITMASK = 0b0000000000000010;
+    constexpr uint16_t SMART_SELF_TEST_SUPPORTED_BITMASK = 0b00000010;
 
-    unsigned char smart_buffer[SIZE_BYTES];
-    std::memcpy(smart_buffer, file_buffer.data() + START_BYTES, SIZE_BYTES);
-    
-
-    //TODO: investigate access of smart_buffer[0]. Shouldn't it be 1 instead, since we're lookign at bit 1, which is in the LSB (second byte of the word)? Is there a better way of checking this?
-    bool smart_support = (smart_buffer[0] & SMART_SELF_TEST_SUPPORTED_BITMASK) != 0;
-    return smart_support;
+    bool smart_supported = (file_buffer[START_BYTES] & SMART_SELF_TEST_SUPPORTED_BITMASK) != 0;
+    return smart_supported;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -41,8 +41,8 @@ std::string extract_model_number(std::array<char, ATA_IDENTIFY_SIZE> &file_buffe
     constexpr std::size_t START_BYTES = 54; // 27th word
     constexpr std::size_t SIZE_BYTES = 40;  // 20 words long
 
-    char buffer[SIZE_BYTES];
-    std::memcpy(buffer, file_buffer.data() + START_BYTES, SIZE_BYTES);
+    std::array<char, SIZE_BYTES> buffer;
+    std::copy(file_buffer.begin() + START_BYTES, file_buffer.begin() + START_BYTES + SIZE_BYTES, buffer.begin());
     std::string model_number;
 
     // 2-word pairs are little endian, so we must flip them

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,7 +1,5 @@
 #include "parser.h"
 
-#include <fstream>
-
 // TODO: it'd be better to define parser as a class and store the file buffer as read-only.
 // TODO: good idea to put `read_file_to_buffer` in the constructor so it throws immediatelly if the file is not valid.
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+#include <array>
+
+constexpr std::size_t ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
+constexpr std::size_t ATA_WORD_SIZE_BYTES = 2;     // 2 bytes per word
+
+
+std::array<char, ATA_IDENTIFY_SIZE> read_file_to_buffer(const std::string& file_path);
+
+std::string extract_model_number(std::array<char, ATA_IDENTIFY_SIZE>& buffer);
+unsigned int extract_dma_mode(std::array<char, ATA_IDENTIFY_SIZE>& buffer);
+bool extract_smart_support(std::array<char, ATA_IDENTIFY_SIZE>& buffer);

--- a/src/parser.h
+++ b/src/parser.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <array>
 #include <fstream>
+#include <algorithm>
 
 constexpr std::size_t ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -3,7 +3,6 @@
 #include <array>
 
 constexpr std::size_t ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
-constexpr std::size_t ATA_WORD_SIZE_BYTES = 2;     // 2 bytes per word
 
 
 std::array<char, ATA_IDENTIFY_SIZE> read_file_to_buffer(const std::string& file_path);

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,12 +1,14 @@
 #pragma once
 #include <string>
 #include <array>
+#include <fstream>
 
 constexpr std::size_t ATA_IDENTIFY_SIZE = 512; // ATA IDENTIFY data structure size in bytes
 
+std::array<char, ATA_IDENTIFY_SIZE> read_file_to_buffer(const std::string &file_path);
 
-std::array<char, ATA_IDENTIFY_SIZE> read_file_to_buffer(const std::string& file_path);
+std::string extract_model_number(std::array<char, ATA_IDENTIFY_SIZE> &buffer);
 
-std::string extract_model_number(std::array<char, ATA_IDENTIFY_SIZE>& buffer);
-unsigned int extract_dma_mode(std::array<char, ATA_IDENTIFY_SIZE>& buffer);
-bool extract_smart_support(std::array<char, ATA_IDENTIFY_SIZE>& buffer);
+unsigned int extract_dma_mode(std::array<char, ATA_IDENTIFY_SIZE> &buffer);
+
+bool extract_smart_support(std::array<char, ATA_IDENTIFY_SIZE> &buffer);


### PR DESCRIPTION
Refactors code, separating it as 2 responsibilities:
- `main.cpp`: arg parsing, function calling and data passing.
- `parser.cpp`: file loading, and binary data parsing.

Fixes the byte ordering for ultra dma mode and smart support parsing. I.e., these two are now parsed correctly.

Replaces printing to `cerr` with throwing an error when something unexpected happens.

Other small improvements.